### PR TITLE
Add GitHub source link to Home and Not Found pages

### DIFF
--- a/src/views/home.tsx
+++ b/src/views/home.tsx
@@ -276,6 +276,11 @@ export function HomePage() {
           <header class="mb-16 bg-white border-4 border-black p-8 neo-shadow relative overflow-hidden">
             <div class="absolute -top-12 -right-12 w-40 h-40 bg-yellow-300 rounded-full border-4 border-black z-0"></div>
             <div class="relative z-10">
+              <a href="https://github.com/jasonpraful/intercom-menu" target="_blank" class="absolute top-0 right-0 hover:scale-110 transition-transform" aria-label="View source on GitHub">
+                <svg class="w-8 h-8" viewBox="0 0 98 96" xmlns="http://www.w3.org/2000/svg">
+                    <path fill-rule="evenodd" clip-rule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" fill="#000"/>
+                </svg>
+              </a>
               <div class="flex flex-row items-start gap-4 md:gap-6 mb-4">
                 <img
                   src="https://storage-us-gcs.bfldr.com/78bxkjwcr4j9z9nfbmjf34n/v/1186671907/original/Intercom_Squinge_Black.png?Expires=1763922530&KeyName=gcs-bfldr-prod&Signature=LpCmXb_h-7iGdf_x6ptZeOu_YpE="

--- a/src/views/not-found.tsx
+++ b/src/views/not-found.tsx
@@ -19,6 +19,11 @@ export function NotFoundPage() {
           <header class="mb-16 bg-white border-4 border-black p-8 neo-shadow relative overflow-hidden">
             <div class="absolute -top-12 -right-12 w-40 h-40 bg-red-500 rounded-full border-4 border-black z-0"></div>
             <div class="relative z-10">
+              <a href="https://github.com/jasonpraful/intercom-menu" target="_blank" class="absolute top-0 right-0 hover:scale-110 transition-transform" aria-label="View source on GitHub">
+                <svg class="w-8 h-8" viewBox="0 0 98 96" xmlns="http://www.w3.org/2000/svg">
+                    <path fill-rule="evenodd" clip-rule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" fill="#000"/>
+                </svg>
+              </a>
               <div class="flex flex-row items-start gap-4 md:gap-6 mb-4">
                 <img 
                   src="https://storage-us-gcs.bfldr.com/78bxkjwcr4j9z9nfbmjf34n/v/1186671907/original/Intercom_Squinge_Black.png?Expires=1763922530&KeyName=gcs-bfldr-prod&Signature=LpCmXb_h-7iGdf_x6ptZeOu_YpE=" 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -11,6 +11,7 @@
   "name": "intercom-menu",
   "main": "src/index.ts",
   "compatibility_date": "2025-03-10",
+  "preview_urls": true,
   "triggers": {
     "crons": ["0 16 * * 1"]
   },


### PR DESCRIPTION
- Included a link to the GitHub repository in both HomePage and NotFoundPage components.
- Added an SVG icon for visual representation of the link, enhancing user experience and accessibility.