### PR TITLE
Update cron to run Monday 3am UTC

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -12,7 +12,7 @@
   "main": "src/index.ts",
   "compatibility_date": "2025-03-10",
   "triggers": {
-    "crons": ["0 16 * * 1"]
+    "crons": ["0 3 * * 1"]
   },
   "routes": [
     {


### PR DESCRIPTION
### Why?

The menu fetch cron was running at 4pm UTC on Mondays, which is too late in the day. Moving it to 3am UTC so menu data is available before the work day starts.

### How?

Updated the cron expression in `wrangler.jsonc` from `0 16 * * 1` to `0 3 * * 1`.

<sub>Generated with Claude Code</sub>